### PR TITLE
Fixed deployment of base packages to common package registry in OSGi environment.

### DIFF
--- a/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/Activator.java
+++ b/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/Activator.java
@@ -18,6 +18,7 @@ package org.fusesource.camel.component.sap;
 
 import org.fusesource.camel.component.sap.util.ComponentDestinationDataProvider;
 import org.fusesource.camel.component.sap.util.ComponentServerDataProvider;
+import org.fusesource.camel.component.sap.util.Util;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -37,6 +38,7 @@ public class Activator implements BundleActivator {
 	 */
 	public void start(BundleContext bundleContext) throws Exception {
 		Activator.context = bundleContext;
+		Util.ensureBasePackages();
 	}
 
 	/*

--- a/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
+++ b/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
@@ -622,8 +622,10 @@ public class Util {
 		}
 	}
 
-	private static void ensureBasePackages() {
-		Object tmp = XMLTypePackage.eINSTANCE;
+	public static synchronized void ensureBasePackages() {
+		@SuppressWarnings("unused")
+		Object tmp;
+		tmp = XMLTypePackage.eINSTANCE;
 		tmp = XMLNamespacePackage.eINSTANCE;
 		tmp = EcorePackage.eINSTANCE;
 		tmp = RfcPackage.eINSTANCE;

--- a/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
+++ b/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
@@ -97,6 +97,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static String marshal(EObject eObject) throws IOException {
+		ensureBasePackages();
 		URI uri = URI.createFileURI("/"); // ensure relative reference URIs
 		XMLResource resource = new XMLResourceImpl(uri);
 		eObject = EcoreUtil.copy(eObject);
@@ -124,6 +125,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static EObject unmarshal(String string) throws IOException {
+		ensureBasePackages();
 		URI uri = URI.createFileURI("/"); // ensure relative reference URIs
 		XMLResource resource = new XMLResourceImpl(uri);
 		StringReader in = new StringReader(string);
@@ -152,7 +154,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static void save(File file, EObject eObject) throws IOException {
-		ensureXMLPackages();
+		ensureBasePackages();
 		URI uri = URI.createFileURI(file.getAbsolutePath());
 		Resource res = new XMLResourceImpl(uri);
 		eObject = EcoreUtil.copy(eObject);
@@ -175,7 +177,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static EObject load(File file) throws IOException {
-		ensureXMLPackages();
+		ensureBasePackages();
 		URI uri = URI.createFileURI(file.getAbsolutePath());
 		Resource res = new XMLResourceImpl(uri);
 
@@ -291,6 +293,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static OutputStream toOutputStream(EObject eObject) throws IOException {
+		ensureBasePackages();
 		XMLResource resource = new XMLResourceImpl();
 		eObject = EcoreUtil.copy(eObject);
 		resource.getContents().add(eObject);
@@ -307,6 +310,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static void print(EObject eObject) throws IOException {
+		ensureBasePackages();
 		XMLResource resource = new XMLResourceImpl();
 		resource.getContents().add(eObject);
 		resource.save(System.out, null);
@@ -433,6 +437,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static void saveRegistry(File file) throws IOException {
+		ensureBasePackages();
 		ResourceSet resourceSet = new ResourceSetImpl();
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore", new EcoreResourceFactoryImpl());
 
@@ -465,6 +470,7 @@ public class Util {
 	 * @throws IOException
 	 */
 	public static void loadRegistry(File file) throws IOException {
+		ensureBasePackages();
 		ResourceSet resourceSet = new ResourceSetImpl();
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore", new EcoreResourceFactoryImpl());
 		resourceSet.getPackageRegistry().put(eNS_URI, IdocPackage.eINSTANCE);
@@ -616,9 +622,11 @@ public class Util {
 		}
 	}
 
-	private static void ensureXMLPackages() {
+	private static void ensureBasePackages() {
 		Object tmp = XMLTypePackage.eINSTANCE;
 		tmp = XMLNamespacePackage.eINSTANCE;
 		tmp = EcorePackage.eINSTANCE;
+		tmp = RfcPackage.eINSTANCE;
+		tmp = IdocPackage.eINSTANCE;
 	}
 }


### PR DESCRIPTION
Added call to Util.ensureBasePackages
to Bundle Activator start method to ensure all base
packages are populated in the AppClassLoader package
registry of SAP Camel Component bundle when operating
in OSGi environment. This will ensure that they are
initialized and available to all bundles referencing
the SAP Camel Component bundle. Also added
synchronization to Util.ensureBasePackages method
to ensure proper initialization of base packages
in multithreaded environment.