### PR TITLE
[ENTESB-7034] Added call to Util.ensureBasePackages

### DIFF
--- a/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/Activator.java
+++ b/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/Activator.java
@@ -18,6 +18,7 @@ package org.fusesource.camel.component.sap;
 
 import org.fusesource.camel.component.sap.util.ComponentDestinationDataProvider;
 import org.fusesource.camel.component.sap.util.ComponentServerDataProvider;
+import org.fusesource.camel.component.sap.util.Util;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -37,6 +38,7 @@ public class Activator implements BundleActivator {
 	 */
 	public void start(BundleContext bundleContext) throws Exception {
 		Activator.context = bundleContext;
+		Util.ensureBasePackages();
 	}
 
 	/*

--- a/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
+++ b/camel-sap/org.fusesource.camel.component.sap/src/org/fusesource/camel/component/sap/util/Util.java
@@ -616,9 +616,13 @@ public class Util {
 		}
 	}
 
-	private static void ensureXMLPackages() {
-		Object tmp = XMLTypePackage.eINSTANCE;
+	public static synchronized void ensureBasePackages() {
+		@SuppressWarnings("unused")
+		Object tmp;
+		tmp = XMLTypePackage.eINSTANCE;
 		tmp = XMLNamespacePackage.eINSTANCE;
 		tmp = EcorePackage.eINSTANCE;
+        tmp = RfcPackage.eINSTANCE;
+        tmp = IdocPackage.eINSTANCE;
 	}
 }


### PR DESCRIPTION
to Bundle Activator start method to ensure all base
packages are populated in the AppClassLoader package
registry of SAP Camel Component bundle when operating
in OSGi environment. This will ensure that they are
initialized and available to all bundles referencing
the SAP Camel Component bundle. Also added
synchronization to Util.ensureBasePackages method
to ensure proper initialization of base packages
in multithreaded environment.