### PR TITLE
Change versions to 7.0.0-SNAPSHOT.

### DIFF
--- a/camel-sap/camel-sap-component/pom.xml
+++ b/camel-sap/camel-sap-component/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2015 Red Hat, Inc. Red Hat licenses this file to you under 
-	the Apache License, version 2.0 (the "License"); you may not use this file 
-	except in compliance with the License. You may obtain a copy of the License 
-	at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
-	law or agreed to in writing, software distributed under the License is distributed 
-	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-	express or implied. See the License for the specific language governing permissions 
+<!-- Copyright 2015 Red Hat, Inc. Red Hat licenses this file to you under
+	the Apache License, version 2.0 (the "License"); you may not use this file
+	except in compliance with the License. You may obtain a copy of the License
+	at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+	law or agreed to in writing, software distributed under the License is distributed
+	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+	express or implied. See the License for the specific language governing permissions
 	and limitations under the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -16,7 +16,7 @@
 	<parent>
 		<artifactId>camel-sap-parent</artifactId>
 		<groupId>org.fusesource</groupId>
-		<version>7.0.0.redhat-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-sap</artifactId>
@@ -335,7 +335,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<reuseForks>false</reuseForks><!-- Added to resolve issues with multiple 
+					<reuseForks>false</reuseForks><!-- Added to resolve issues with multiple
 						loading of JCo native library -->
 					<argLine>-Djava.library.path="${native.lib.directory}"</argLine>
 				</configuration>
@@ -347,7 +347,7 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -429,7 +429,7 @@
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
             </releases>
-        </repository>		
+        </repository>
 	</repositories>
 
 </project>

--- a/camel-sap/camel-sap-starter/pom.xml
+++ b/camel-sap/camel-sap-starter/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.fusesource</groupId>
 	<artifactId>camel-sap-starter</artifactId>
-	<version>7.0.0.redhat-SNAPSHOT</version>
+	<version>7.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JBoss Fuse :: Components :: SAP JCO :: Spring-Boot Starter</name>

--- a/camel-sap/org.fusesource.camel.component.sap.model.edit/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap.model.edit/pom.xml
@@ -23,7 +23,7 @@
   <parent>
   	<groupId>org.fusesource</groupId>
   	<artifactId>camel-sap-parent</artifactId>
-  	<version>7.0.0.redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
   </parent>
   
   <build>
@@ -46,7 +46,6 @@
   </build>
   <url>http://www.jboss.org/products/fuse/overview/</url>
   <name>JBoss Fuse :: SAP JCO :: SAP Data Layer :: Edit Plugin</name>
-  <version>7.0.0-SNAPSHOT</version>
   <description>Provides EMF Item Providers for Fuse Tooling to manipulate SAP Data Layer models</description>
   <organization>
   	<name>Red Hat, Inc.</name>

--- a/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
@@ -41,7 +41,7 @@
   <parent>
   	<groupId>org.fusesource</groupId>
   	<artifactId>camel-sap-parent</artifactId>
-  	<version>7.0.0.redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
   </parent>
   <url>http://www.jboss.org/products/fuse/overview/</url>
   <name>JBoss Fuse :: SAP JCO :: SAP Data Layer :: Model Plugin</name>
@@ -50,5 +50,4 @@
   	<name>Red Hat, Inc.</name>
   	<url>http://www.redhat.com</url>
   </organization>
-  <version>7.0.0-SNAPSHOT</version>
 </project>

--- a/camel-sap/org.fusesource.camel.component.sap.test/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.fusesource</groupId>
 		<artifactId>camel-sap-parent</artifactId>
-		<version>7.0.0.redhat-SNAPSHOT</version>
+		<version>7.0.0-SNAPSHOT</version>
 	</parent>
 
 	<name>JBoss Fuse :: SAP JCO :: SAP Data Layer :: Test Plugin</name>
@@ -262,6 +262,5 @@
     	</dependency>
 	</dependencies>
 
-	<version>7.0.0-SNAPSHOT</version>
 	<url>http://www.jboss.org/products/fuse/overview/</url>
 </project>

--- a/camel-sap/org.fusesource.camel.component.sap/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.fusesource</groupId>
 		<artifactId>camel-sap-parent</artifactId>
-		<version>7.0.0.redhat-SNAPSHOT</version>
+		<version>7.0.0-SNAPSHOT</version>
 	</parent>
 
 	<packaging>eclipse-plugin</packaging>
@@ -53,7 +53,6 @@
 		</plugins>
 	</build>
 
-	<version>7.0.0-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>

--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>org.fusesource</groupId>
 	<artifactId>camel-sap-parent</artifactId>
-	<version>7.0.0.redhat-SNAPSHOT</version>
+	<version>7.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>JBoss Fuse :: Components :: SAP JCO</name>


### PR DESCRIPTION
I'd like to propose moving versions to 7.0.0-SNAPSHOT.    I'm trying to provide a fix for https://issues.jboss.org/browse/ENTESB-7442 and I'm running into a few issues because of a few issues : 

- org.fusesource.camel.component.sap,  org.fusesource.camel.component.sap.model,  org.fusesource.camel.component.sap.model.edit,  org.fusesource.camel.component.sap.test all have a version of 7.0.0-SNAPSHOT but a parent version of 7.0.0.redhat-SNAPSHOT - this seems inconsistent

- I can't seem to change everything to a 7.0.0.redhat-SNAPSHOT because of the manifests - the tycho plugin doesn't seem to accept 7.0.0.redhat-qualifier, and complains that the manifest version is inconsistent if i try anything other than that

One of the files in this diff had CRLF issues, the only line changed there is the version.