### PR TITLE
Add a sources jar and a distributionManagement section.

### DIFF
--- a/camel-sap/camel-sap-starter/pom.xml
+++ b/camel-sap/camel-sap-starter/pom.xml
@@ -79,6 +79,19 @@
 		</resources>
 		
 		<plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-source-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>attach-sources</id>
+                                    <phase>process-classes</phase>
+                                    <goals>
+                                        <goal>jar</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
@@ -112,7 +125,19 @@
 			</plugin>
 		</plugins>
 	</build>	
-	
+
+        <distributionManagement>
+            <repository>
+                <id>jboss-releases-repository</id>
+                <name>JBoss Releases Repository</name>
+                <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2</url>
+            </repository>
+            <snapshotRepository>
+                <id>jboss-snapshots-repository</id>
+                <name>JBoss Snapshots Repository</name>
+                <url>https://repository.jboss.org/nexus/content/repositories/snapshots</url>
+            </snapshotRepository>
+        </distributionManagement>
 	<repositories>
 		<repository>
 			<id>fusesource-third-party-internal</id>


### PR DESCRIPTION
Add a sources JAR and a distributionManagement section to the camel-sap-starter module.    camel-sap-starter inherits from parent org.springframework.boot:spring-boot-starter-parent, so it needs it's own source JAR and distributionManagement specification (because it does not inherit from camel-sap-parent).