### PR TITLE
ENTESB-7579 Add support for fuse-components camel-sap component on Karaf

### DIFF
--- a/camel-sap/camel-sap-component/src/main/resources/features.xml
+++ b/camel-sap/camel-sap-component/src/main/resources/features.xml
@@ -17,8 +17,8 @@
   -->
 <features name="camel-sap-${project.version}">
     <repository>mvn:org.apache.camel.karaf/apache-camel/${camel-version}/xml/features</repository>
-    <repository>mvn:org.apache.karaf.assemblies.features/standard/${karaf-version}/xml/features</repository>
-    <repository>mvn:org.apache.karaf.assemblies.features/enterprise/${karaf-version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/standard/${karaf-version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/enterprise/${karaf-version}/xml/features</repository>
 
     <feature name="camel-sap" version="${project.version}" resolver="(obr)">
         <feature>camel-core</feature>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-7579

The groupId for the karaf standard/enterprise features have changed in Fuse 7, need to respond to that.