### PR TITLE
Revert "missed a switch to https for repo urls" - jenkins fails with …

### DIFF
--- a/camel-sap/camel-sap-repository/pom.xml
+++ b/camel-sap/camel-sap-repository/pom.xml
@@ -219,7 +219,7 @@
 		<repository>
             <id>brewroot</id>
             <name>Brew Repository</name>
-            <url>https://download.eng.bos.redhat.com/brewroot/repos/jb-fuse-6.2-build/latest/maven</url>
+            <url>http://download.eng.bos.redhat.com/brewroot/repos/jb-fuse-6.2-build/latest/maven</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
…https for brew repo

This reverts commit 4b78bf14f9c722230b048d3f7752d97a4488f5f6.