### PR TITLE
ENTESB-10551: Fixed some Jackson 2 related CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,16 @@
         <camel-version>2.21.0.fuse-740038</camel-version>
         <activemq-version>5.11.0.redhat-630396</activemq-version>
         <karaf-version>4.2.0.fuse-740017</karaf-version>
+        <jackson2-version>2.8.11</jackson2-version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson2-version}.3</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>apt</artifactId>


### PR DESCRIPTION
It's overriding jackson2-version from parent-pom to 2.8.11. And then forcing jackson-databind to 2.8.11.3 that contains some CVE fixes.