### PR TITLE
Removed eclipse-neon from repositories section

### DIFF
--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -434,17 +434,6 @@
         </modules>
 	<repositories>
 		<repository>
-			<id>eclipse-neon</id>
-			<url>http://download.eclipse.org/releases/neon/</url>
-			<layout>p2</layout>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-		<repository>
 			<id>brewroot</id>
 			<name>Brew Repository</name>
 			<url>http://download.eng.bos.redhat.com/brewroot/repos/jb-fuse-6.2-build/latest/maven</url>


### PR DESCRIPTION
The eclispse-neon repository is still present in a profile that is active provided the productisation property isn't set. Brew builds fail when this repository is present as it cannot access external URLs.