### PR TITLE
ENTESB-13928 Remove ea repository from fuse-components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <geronimo-jms_1.1_spec.version>1.1.1.redhat-2</geronimo-jms_1.1_spec.version>
         <commons-pool.version>1.6.0.redhat-9</commons-pool.version>
         <commons-net.version>3.6</commons-net.version>
-        <camel-version>2.21.0.fuse-740038</camel-version>
+        <camel-version>2.21.0.fuse-770009</camel-version>
         <activemq-version>5.11.0.redhat-630446</activemq-version>
-        <karaf-version>4.2.0.fuse-740017</karaf-version>
+        <karaf-version>4.2.6.fuse-770010</karaf-version>
         <!-- ENTESB-12869: versions from com.fasterxml.jackson/jackson-bom/2.8.11.20200310-redhat-00001 -->
         <jackson2-version>2.8.11</jackson2-version>
         <jackson2-databind-version>2.8.11.6-redhat-00001</jackson2-databind-version>
@@ -97,17 +97,6 @@
     </modules>
     <repositories>
         <repository>
-            <id>jboss-ea</id>
-            <name>Fuse Early Access Repository</name>
-            <url>https://repository.jboss.org/nexus/content/groups/ea</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-        <repository>
             <id>jboss.public.repo</id>
             <name>JBoss Public Repository</name>
             <url>https://repository.jboss.org/nexus/content/repositories/public</url>
@@ -129,11 +118,4 @@
             </snapshots>
         </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jboss-ea</id>
-            <url>https://repository.jboss.org/nexus/content/groups/ea</url>
-            <layout>default</layout>
-        </pluginRepository>
-    </pluginRepositories>
 </project>


### PR DESCRIPTION
We need to remove the ea repository from being defined in fuse-components.     PNC is seeing the definition of the ea repository and is adding that to the list of repositories it will look at - and when we build fuse-components in PNC, we need builds to fail when they are not aligned.

This change requires that developers have it set in their settings.xml files.   