### PR TITLE
ENTESB-17379: bump SAP JCo version to 3.1.4 and IDOC to 3.1.1

### DIFF
--- a/camel-sap/camel-sap-component/pom.xml
+++ b/camel-sap/camel-sap-component/pom.xml
@@ -142,12 +142,12 @@
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.idoc</groupId>
 			<artifactId>com.sap.conn.idoc</artifactId>
-			<version>3.1.0.redhat-00001</version>
+			<version>3.1.1.redhat-00001</version>
 		</dependency>
 
 		<dependency>

--- a/camel-sap/camel-sap-repository/org.fusesource.camel.component.sap.feature/feature.xml
+++ b/camel-sap/camel-sap-repository/org.fusesource.camel.component.sap.feature/feature.xml
@@ -31,7 +31,7 @@ permissions and limitations under the License.
    </license>
 
    <requires>
-      <import plugin="com.sap.conn.jco" version="3.1.2.redhat-00001" match="greaterOrEqual"/>
+      <import plugin="com.sap.conn.jco" version="3.1.4.redhat-00001" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.emf.ecore.xmi"/>
       <import plugin="org.slf4j.api"/>
@@ -64,7 +64,7 @@ permissions and limitations under the License.
          fragment="true"
          unpack="false"/>
 
-   <!-- NOT SUPPORT in 3.1.2
+   <!-- NOT SUPPORT in 3.1.4
    <plugin
          id="com.sap.conn.jco.osx.x86"
          os="macosx"
@@ -77,7 +77,7 @@ permissions and limitations under the License.
          unpack="false"/>
    -->
 
-   <!-- NOT SUPPORT in 3.1.2
+   <!-- NOT SUPPORT in 3.1.4
    <plugin
          id="com.sap.conn.jco.linux.x86"
          os="linux"

--- a/camel-sap/camel-sap-repository/pom.xml
+++ b/camel-sap/camel-sap-repository/pom.xml
@@ -144,46 +144,46 @@
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
-		<!-- NOT SUPPORT in 3.1.2
+		<!-- NOT SUPPORT in 3.1.4
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.linux.x86</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		-->
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.linux.x86_64</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
-                <!-- NOT SUPPORT in 3.1.2
+                <!-- NOT SUPPORT in 3.1.4
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.osx.x86</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		-->
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.osx.x86_64</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.win32.x86</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco.win32.x86_64</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.idoc</groupId>
 			<artifactId>com.sap.conn.idoc</artifactId>
-			<version>3.1.0.redhat-00001</version>
+			<version>3.1.1.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>org.fusesource</groupId>

--- a/camel-sap/camel-sap-starter/pom.xml
+++ b/camel-sap/camel-sap-starter/pom.xml
@@ -22,8 +22,8 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<camel-version>2.21.0.fuse-740038</camel-version>
-		<sapjco3-version>3.1.2</sapjco3-version>
-		<sapidoc3-version>3.1.0</sapidoc3-version>
+		<sapjco3-version>3.1.4</sapjco3-version>
+		<sapidoc3-version>3.1.1</sapidoc3-version>
 		<lib.directory>${project.build.directory}/lib</lib.directory>
                 <logback-version>1.2.3.redhat-00001</logback-version>
 	</properties>

--- a/camel-sap/com.sap.conn.idoc/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.idoc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP IDoc Class Library v3
 Bundle-SymbolicName: com.sap.conn.idoc
-Bundle-Version: 3.1.0.redhat-00001
+Bundle-Version: 3.1.1.redhat-00001
 Bundle-ClassPath: sapidoc3.jar
 Bundle-Vendor: Red Hat, Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/camel-sap/com.sap.conn.idoc/pom.xml
+++ b/camel-sap/com.sap.conn.idoc/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.sap.conn.idoc</groupId>
   <artifactId>com.sap.conn.idoc</artifactId>
-  <version>3.1.0.redhat-00001</version>
+  <version>3.1.1.redhat-00001</version>
   <packaging>eclipse-plugin</packaging>
   <name>SAP IDoc Class Library v3 Plugin</name>
   <description>Builds Plugin exporting the IDoc Class Library v3</description>
@@ -53,7 +53,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.idoc</groupId>
 									<artifactId>sapidoc3</artifactId>
-									<version>3.1.0</version>
+									<version>3.1.1</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 								</artifactItem>

--- a/camel-sap/com.sap.conn.jco.linux.x86/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.linux.x86/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for Linux (32-bit x86)
 Bundle-SymbolicName: com.sap.conn.jco.linux.x86
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: libsapjco3.so
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.linux.x86/pom.xml
+++ b/camel-sap/com.sap.conn.jco.linux.x86/pom.xml
@@ -18,7 +18,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.conn.jco</groupId>
 	<artifactId>com.sap.conn.jco.linux.x86</artifactId>
-	<version>3.1.2.redhat-00001</version>
+	<version>3.1.4.redhat-00001</version>
 	<packaging>eclipse-plugin</packaging>
 	<parent>
 		<groupId>org.fusesource</groupId>
@@ -75,7 +75,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>linux-i686</classifier>
 									<type>so</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco.linux.x86_64/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for Linux (64-bit x86)
 Bundle-SymbolicName: com.sap.conn.jco.linux.x86_64
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: libsapjco3.so
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.linux.x86_64/pom.xml
+++ b/camel-sap/com.sap.conn.jco.linux.x86_64/pom.xml
@@ -17,7 +17,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.conn.jco</groupId>
 	<artifactId>com.sap.conn.jco.linux.x86_64</artifactId>
-	<version>3.1.2.redhat-00001</version>
+	<version>3.1.4.redhat-00001</version>
 	<packaging>eclipse-plugin</packaging>
 	<parent>
 		<groupId>org.fusesource</groupId>
@@ -76,7 +76,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>linux-x86_64</classifier>
 									<type>so</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco.osx.x86/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.osx.x86/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for OS X (32-bit Intel)
 Bundle-SymbolicName: com.sap.conn.jco.osx.x86
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: libsapjco3.dylib
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.osx.x86/pom.xml
+++ b/camel-sap/com.sap.conn.jco.osx.x86/pom.xml
@@ -18,7 +18,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.conn.jco</groupId>
 	<artifactId>com.sap.conn.jco.osx.x86</artifactId>
-	<version>3.1.2.redhat-00001</version>
+	<version>3.1.4.redhat-00001</version>
 	<packaging>eclipse-plugin</packaging>
 	<parent>
 		<groupId>org.fusesource</groupId>
@@ -85,7 +85,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>macosx-i686</classifier>
 									<type>dylib</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco.osx.x86_64/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.osx.x86_64/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for OS X (64-bit Intel)
 Bundle-SymbolicName: com.sap.conn.jco.osx.x86_64
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: libsapjco3.dylib
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.osx.x86_64/pom.xml
+++ b/camel-sap/com.sap.conn.jco.osx.x86_64/pom.xml
@@ -17,7 +17,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.conn.jco</groupId>
 	<artifactId>com.sap.conn.jco.osx.x86_64</artifactId>
-	<version>3.1.2.redhat-00001</version>
+	<version>3.1.4.redhat-00001</version>
 	<packaging>eclipse-plugin</packaging>
 	<parent>
 		<groupId>org.fusesource</groupId>
@@ -84,7 +84,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>macosx-x86_64</classifier>
 									<type>dylib</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco.win32.x86/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.win32.x86/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for Windows (32-bit x86)
 Bundle-SymbolicName: com.sap.conn.jco.win32.x86
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: sapjco3.dll
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.win32.x86/pom.xml
+++ b/camel-sap/com.sap.conn.jco.win32.x86/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>com.sap.conn.jco</groupId>
   <artifactId>com.sap.conn.jco.win32.x86</artifactId>
-  <version>3.1.2.redhat-00001</version>
+  <version>3.1.4.redhat-00001</version>
   <packaging>eclipse-plugin</packaging>
 	<name>SAP Java Connector v3 - Native Library for Windows (32-bit x86) Plugin</name>
 	<url>http://www.fusesource.org</url>
@@ -67,7 +67,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>win-i686</classifier>
 									<type>dll</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco.win32.x86_64/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3 - Native Libraries for Windows (64-bit x86)
 Bundle-SymbolicName: com.sap.conn.jco.win32.x86_64
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-Vendor: Red Hat, Inc.
-Fragment-Host: com.sap.conn.jco;bundle-version="3.1.2.redhat-00001"
+Fragment-Host: com.sap.conn.jco;bundle-version="3.1.4.redhat-00001"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-NativeCode: sapjco3.dll
 Bundle-ClassPath: .

--- a/camel-sap/com.sap.conn.jco.win32.x86_64/pom.xml
+++ b/camel-sap/com.sap.conn.jco.win32.x86_64/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>com.sap.conn.jco</groupId>
   <artifactId>com.sap.conn.jco.win32.x86_64</artifactId>
-  <version>3.1.2.redhat-00001</version>
+  <version>3.1.4.redhat-00001</version>
   <packaging>eclipse-plugin</packaging>
 	<name>SAP Java Connector v3 - Native Library for Windows (64-bit x86) Plugin</name>
 	<url>http://www.fusesource.org</url>
@@ -67,7 +67,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<classifier>win-x86_64</classifier>
 									<type>dll</type>
 									<overWrite>true</overWrite>

--- a/camel-sap/com.sap.conn.jco/META-INF/MANIFEST.MF
+++ b/camel-sap/com.sap.conn.jco/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP Java Connector v3
 Bundle-SymbolicName: com.sap.conn.jco
-Bundle-Version: 3.1.2.redhat-00001
+Bundle-Version: 3.1.4.redhat-00001
 Bundle-ClassPath: sapjco3.jar
 Bundle-Vendor: Red Hat, Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/camel-sap/com.sap.conn.jco/pom.xml
+++ b/camel-sap/com.sap.conn.jco/pom.xml
@@ -17,7 +17,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.conn.jco</groupId>
 	<artifactId>com.sap.conn.jco</artifactId>
-	<version>3.1.2.redhat-00001</version>
+	<version>3.1.4.redhat-00001</version>
 	<packaging>eclipse-plugin</packaging>
 	<parent>
 		<groupId>org.fusesource</groupId>
@@ -66,7 +66,7 @@
 								<artifactItem>
 									<groupId>com.sap.conn.jco</groupId>
 									<artifactId>sapjco3</artifactId>
-									<version>3.1.2</version>
+									<version>3.1.4</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 								</artifactItem>

--- a/camel-sap/org.fusesource.camel.component.sap.test/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap.test/pom.xml
@@ -213,12 +213,12 @@
                 <dependency>
                         <groupId>com.sap.conn.jco</groupId>
                         <artifactId>com.sap.conn.jco</artifactId>
-                        <version>3.1.2.redhat-00001</version>
+                        <version>3.1.4.redhat-00001</version>
                 </dependency>
                 <dependency>
                         <groupId>com.sap.conn.idoc</groupId>
                         <artifactId>com.sap.conn.idoc</artifactId>
-                        <version>3.1.0.redhat-00001</version>
+                        <version>3.1.1.redhat-00001</version>
                 </dependency>
                 <dependency>
                         <groupId>org.fusesource</groupId>

--- a/camel-sap/org.fusesource.camel.component.sap/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap/pom.xml
@@ -56,12 +56,12 @@
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>com.sap.conn.jco</artifactId>
-			<version>3.1.2.redhat-00001</version>
+			<version>3.1.4.redhat-00001</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.idoc</groupId>
 			<artifactId>com.sap.conn.idoc</artifactId>
-			<version>3.1.0.redhat-00001</version>
+			<version>3.1.1.redhat-00001</version>
 		</dependency>
 	</dependencies>
 	<url>http://www.jboss.org/products/fuse/overview/</url>

--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -170,17 +170,17 @@
 			<dependency>
 				<groupId>com.sap.conn.idoc</groupId>
 				<artifactId>sapidoc3</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.sap.conn.jco</groupId>
 				<artifactId>sapjco3</artifactId>
-				<version>3.1.2</version>
+				<version>3.1.4</version>
 			</dependency>
 			<dependency>
 				<groupId>com.sap.conn.jco</groupId>
 				<artifactId>sapjco3</artifactId>
-				<version>3.1.2</version>
+				<version>3.1.4</version>
 				<type>${envType}</type>
 				<classifier>${envClassifier}</classifier>
 				<scope>test</scope>
@@ -234,12 +234,12 @@
                 <dependency>
                         <groupId>com.sap.conn.jco</groupId>
                         <artifactId>com.sap.conn.jco</artifactId>
-                        <version>3.1.2.redhat-00001</version>
+                        <version>3.1.4.redhat-00001</version>
                 </dependency>
                 <dependency>
                         <groupId>com.sap.conn.idoc</groupId>
                         <artifactId>com.sap.conn.idoc</artifactId>
-                        <version>3.1.0.redhat-00001</version>
+                        <version>3.1.1.redhat-00001</version>
                 </dependency>
         </dependencies>
 	<profiles>
@@ -450,11 +450,11 @@
                         <id>repository</id>
                         <modules>
     							<!-- these 6 SAP bundles are only used at build time as per ENTESB-5801 -->
-				<!-- NOT SUPPORT in 3.1.2
+				<!-- NOT SUPPORT in 3.1.4
                                 <module>com.sap.conn.jco.linux.x86</module>
 				-->
                                 <module>com.sap.conn.jco.linux.x86_64</module>
-				<!-- NOT SUPPORT in 3.1.2
+				<!-- NOT SUPPORT in 3.1.4
                                 <module>com.sap.conn.jco.osx.x86</module>
 				-->
                                 <module>com.sap.conn.jco.osx.x86_64</module>


### PR DESCRIPTION
Update the JCo and IDOC to support additional architectures (ppc64le,s390x)