### PR TITLE
Use productized version of camel-spring

### DIFF
--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -53,7 +53,7 @@
 			<dependency>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-spring</artifactId>
-				<version>${camel-community-version}</version>
+				<version>${camel-version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.camel</groupId>


### PR DESCRIPTION
camel-spring was recently productized - we need to use the productized version or else the community version (needed for plugins) is overwritten by PME