### PR TITLE
Set provided scope for SAP libraries

### DIFF
--- a/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
+++ b/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
@@ -232,10 +232,12 @@
         <dependency>
             <groupId>com.sap.conn.idoc</groupId>
             <artifactId>sapidoc3</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sap.conn.jco</groupId>
             <artifactId>sapjco3</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Change SAP to provided scope as we've done for camel-sap