### PR TITLE
Remove optional declartion from camel-sap component dependencies

### DIFF
--- a/camel-sap/camel-sap-component/pom.xml
+++ b/camel-sap/camel-sap-component/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-core-model</artifactId>
-			<scope>provided</scope>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.conn.jco</groupId>
@@ -53,31 +53,26 @@
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.common</artifactId>
 			<scope>compile</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore</artifactId>
 			<scope>compile</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore.change</artifactId>
 			<scope>compile</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore.xmi</artifactId>
 			<scope>compile</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.edit</artifactId>
 			<scope>compile</scope>
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -97,7 +92,6 @@
 		<dependency>
 			<groupId>org.fusesource</groupId>
 			<artifactId>org.fusesource.camel.component.sap</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.fusesource</groupId>


### PR DESCRIPTION
The [recent change](https://github.com/jboss-fuse/fuse-components/commit/184fd8d20d23a36815e3f5ff150268cb291eb20f) to remove the `maven-bundle-plugin` has some side effects.

Previously, most of the `camel-sap` component dependencies were declared as `optional`  as the bundle plugin was shading them into the component JAR. Since that's been removed, those dependencies become mandatory.

Assuming we keep things in the current state and do not revert 184fd8d20d23a36815e3f5ff150268cb291eb20f, I think it means that the `org.eclipse.emf` libs will need to be productized.