### PR TITLE
Camel-cics fix commare length initialization for type channel

### DIFF
--- a/camel-cics/src/main/java/com/redhat/camel/component/cics/CICSProducer.java
+++ b/camel-cics/src/main/java/com/redhat/camel/component/cics/CICSProducer.java
@@ -73,6 +73,12 @@ public class CICSProducer extends DefaultProducer {
 
         ECIRequest request = configuration.getOrCreateEciBinding().toECIRequest(exchange, configuration);
         request.Commarea_Length = 32768;
+
+        //if there is no byte[] in commarea, the commarea_length is set to 0 and requests (channel type) fail
+        if(request.Commarea == null) {
+            request.Commarea = new byte[18];
+        }
+
         CICSGatewayFactory gf = configuration.getOrCreateGatewayFactory();
         try (CICSGateway gw = gf.createGateway()) {
             gw.open();


### PR DESCRIPTION
If dataExchangeType is `channel`. The commare can not be empty.
```
 CTG6670E Exception occurred in the Gateway daemon: [java.lang.RuntimeException: Commarea too small: 0]
 ```
 It is not enough to set the length, also the data field has to be initialized. (the minimum working length is 17.