### PR TITLE
Upgrade parent to 4.14.0; upgrade JDK to 17

### DIFF
--- a/camel-cics/pom.xml
+++ b/camel-cics/pom.xml
@@ -39,9 +39,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <slf4j-api-version>2.0.12.redhat-00001</slf4j-api-version>
+        <slf4j-api-version>2.0.17</slf4j-api-version>
         <cgtclient-version>9.2</cgtclient-version>
-        <camel-version>4.10.6</camel-version>
+        <camel-version>4.14.0</camel-version>
         <jdk.version>17</jdk.version>
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>

--- a/camel-cics/src/generated/resources/META-INF/com/redhat/camel/component/cics/cics.json
+++ b/camel-cics/src/generated/resources/META-INF/com/redhat/camel/component/cics/cics.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.fusesource",
     "artifactId": "camel-cics",
-    "version": "4.10.6-SNAPSHOT",
+    "version": "4.14.0-SNAPSHOT",
     "scheme": "cics",
     "extendsScheme": "",
     "syntax": "cics:\/\/interfaceType\/[dataExchangeType][?options]",

--- a/camel-cics/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/camel-cics/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -2,6 +2,6 @@
 components=cics
 groupId=org.fusesource
 artifactId=camel-cics
-version=4.10.6-SNAPSHOT
+version=4.14.0-SNAPSHOT
 projectName=JBoss Fuse :: Components :: CICS Transaction Gateway
 projectDescription=Camel CICS Transaction Gateway component

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/converter/CamelSapBulkConverterLoader.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/converter/CamelSapBulkConverterLoader.java
@@ -54,11 +54,7 @@ public final class CamelSapBulkConverterLoader implements TypeConverterLoader, B
     public <T> T convertTo(Class<?> from, Class<T> to, Exchange exchange, Object value) throws TypeConversionException {
         try {
             Object obj = doConvertTo(from, to, exchange, value);
-            if (obj == Void.class) {;
-                return null;
-            } else {
-                return (T) obj;
-            }
+            return (T) obj;
         } catch (TypeConversionException e) {
             throw e;
         } catch (Exception e) {

--- a/camel-sap/camel-sap-component/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/camel-sap/camel-sap-component/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -2,6 +2,6 @@
 components=ap-srfc-server sap-clear-cache sap-idoc-destination sap-idoclist-destination sap-idoclist-server sap-qidoc-destination sap-qidoclist-destination sap-qrfc-destination sap-srfc-destination sap-srfc-server sap-trfc-destination sap-trfc-server
 groupId=org.fusesource
 artifactId=camel-sap
-version=4.10.6-SNAPSHOT
+version=4.14.0-SNAPSHOT
 projectName=JBoss Fuse :: Components :: SAP JCO :: Camel Component
 projectDescription=Provides SAP Camel Component Layer

--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -28,13 +28,13 @@
 	<url>http://www.jboss.org/products/fuse/overview/</url>
 
 	<properties>
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<maven-bundle-plugin-version>5.1.8</maven-bundle-plugin-version>
-		<camel-version>4.10.6</camel-version>
-		<camel-community-version>4.10.6</camel-community-version>
-		<camel.sap.plugin.version>4.10.6-SNAPSHOT</camel.sap.plugin.version>
+		<camel-version>4.14.0</camel-version>
+		<camel-community-version>4.14.0</camel-community-version>
+		<camel.sap.plugin.version>4.14.0-SNAPSHOT</camel.sap.plugin.version>
 		<mockito.version>3.12.4</mockito.version>
 		<powermock.version>2.0.2</powermock.version>
 		<hamcrest.version>2.1</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-parent</artifactId>
-        <version>4.10.6</version>
+        <version>4.14.0</version>
     </parent>
 
     <groupId>org.fusesource</groupId>


### PR DESCRIPTION
Change versions to 4.14.0; upgrade JDK used for camel-sap to JDK 17.     cics was already using JDK 17.