### PR TITLE
Change EndpointUriFactory to respond to changes in CAMEL-22486

### DIFF
--- a/camel-cics/src/generated/java/com/redhat/camel/component/cics/CICSEndpointUriFactory.java
+++ b/camel-cics/src/generated/java/com/redhat/camel/component/cics/CICSEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class CICSEndpointUriFactory extends org.apache.camel.support.component.E
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(18);
         props.add("ctgDebug");
@@ -48,7 +48,7 @@ public class CICSEndpointUriFactory extends org.apache.camel.support.component.E
         secretProps.add("sslPassword");
         secretProps.add("userId");
         SECRET_PROPERTY_NAMES = Collections.unmodifiableSet(secretProps);
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -80,7 +80,7 @@ public class CICSEndpointUriFactory extends org.apache.camel.support.component.E
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapClearCacheEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapClearCacheEndpointUriFactory.java
@@ -21,14 +21,14 @@ public class SapClearCacheEndpointUriFactory extends org.apache.camel.support.co
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(2);
         props.add("lazyStartProducer");
         props.add("name");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -59,7 +59,7 @@ public class SapClearCacheEndpointUriFactory extends org.apache.camel.support.co
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedIDocDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedIDocDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapQueuedIDocDestinationEndpointUriFactory extends org.apache.camel
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(7);
         props.add("applicationRelease");
@@ -33,7 +33,7 @@ public class SapQueuedIDocDestinationEndpointUriFactory extends org.apache.camel
         props.add("systemRelease");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -69,7 +69,7 @@ public class SapQueuedIDocDestinationEndpointUriFactory extends org.apache.camel
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedIDocListDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedIDocListDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapQueuedIDocListDestinationEndpointUriFactory extends org.apache.c
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(7);
         props.add("applicationRelease");
@@ -33,7 +33,7 @@ public class SapQueuedIDocListDestinationEndpointUriFactory extends org.apache.c
         props.add("systemRelease");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -69,7 +69,7 @@ public class SapQueuedIDocListDestinationEndpointUriFactory extends org.apache.c
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedRfcDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapQueuedRfcDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapQueuedRfcDestinationEndpointUriFactory extends org.apache.camel.
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(6);
         props.add("destination");
@@ -32,7 +32,7 @@ public class SapQueuedRfcDestinationEndpointUriFactory extends org.apache.camel.
         props.add("transacted");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class SapQueuedRfcDestinationEndpointUriFactory extends org.apache.camel.
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapSynchronousRfcDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapSynchronousRfcDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapSynchronousRfcDestinationEndpointUriFactory extends org.apache.c
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(5);
         props.add("destination");
@@ -31,7 +31,7 @@ public class SapSynchronousRfcDestinationEndpointUriFactory extends org.apache.c
         props.add("transacted");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SapSynchronousRfcDestinationEndpointUriFactory extends org.apache.c
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapSynchronousRfcServerEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapSynchronousRfcServerEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapSynchronousRfcServerEndpointUriFactory extends org.apache.camel.
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(6);
         props.add("bridgeErrorHandler");
@@ -32,7 +32,7 @@ public class SapSynchronousRfcServerEndpointUriFactory extends org.apache.camel.
         props.add("stateful");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -64,7 +64,7 @@ public class SapSynchronousRfcServerEndpointUriFactory extends org.apache.camel.
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapTransactionalIDocDestinationEndpointUriFactory extends org.apach
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(6);
         props.add("applicationRelease");
@@ -32,7 +32,7 @@ public class SapTransactionalIDocDestinationEndpointUriFactory extends org.apach
         props.add("systemRelease");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -67,7 +67,7 @@ public class SapTransactionalIDocDestinationEndpointUriFactory extends org.apach
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocListDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocListDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapTransactionalIDocListDestinationEndpointUriFactory extends org.a
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(6);
         props.add("applicationRelease");
@@ -32,7 +32,7 @@ public class SapTransactionalIDocListDestinationEndpointUriFactory extends org.a
         props.add("systemRelease");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -67,7 +67,7 @@ public class SapTransactionalIDocListDestinationEndpointUriFactory extends org.a
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocListServerEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalIDocListServerEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapTransactionalIDocListServerEndpointUriFactory extends org.apache
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(10);
         props.add("applicationRelease");
@@ -36,7 +36,7 @@ public class SapTransactionalIDocListServerEndpointUriFactory extends org.apache
         props.add("systemRelease");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -71,7 +71,7 @@ public class SapTransactionalIDocListServerEndpointUriFactory extends org.apache
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalRfcDestinationEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalRfcDestinationEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapTransactionalRfcDestinationEndpointUriFactory extends org.apache
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(5);
         props.add("destination");
@@ -31,7 +31,7 @@ public class SapTransactionalRfcDestinationEndpointUriFactory extends org.apache
         props.add("transacted");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SapTransactionalRfcDestinationEndpointUriFactory extends org.apache
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalRfcServerEndpointUriFactory.java
+++ b/camel-sap/camel-sap-component/src/generated/java/org/fusesource/camel/component/sap/SapTransactionalRfcServerEndpointUriFactory.java
@@ -21,7 +21,7 @@ public class SapTransactionalRfcServerEndpointUriFactory extends org.apache.came
 
     private static final Set<String> PROPERTY_NAMES;
     private static final Set<String> SECRET_PROPERTY_NAMES;
-    private static final Set<String> MULTI_VALUE_PREFIXES;
+    private static final Map<String, String> MULTI_VALUE_PREFIXES;
     static {
         Set<String> props = new HashSet<>(7);
         props.add("bridgeErrorHandler");
@@ -33,7 +33,7 @@ public class SapTransactionalRfcServerEndpointUriFactory extends org.apache.came
         props.add("stateful");
         PROPERTY_NAMES = Collections.unmodifiableSet(props);
         SECRET_PROPERTY_NAMES = Collections.emptySet();
-        MULTI_VALUE_PREFIXES = Collections.emptySet();
+        MULTI_VALUE_PREFIXES = Collections.emptyMap();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class SapTransactionalRfcServerEndpointUriFactory extends org.apache.came
     }
 
     @Override
-    public Set<String> multiValuePrefixes() {
+    public Map<String, String> multiValuePrefixes() {
         return MULTI_VALUE_PREFIXES;
     }
 

--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -32,8 +32,8 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven-surefire-plugin-version>3.5.3</maven-surefire-plugin-version>
 		<maven-bundle-plugin-version>5.1.8</maven-bundle-plugin-version>
-		<camel-version>4.14.4.redhat-00001</camel-version>
-		<camel-community-version>4.14.4</camel-community-version>
+		<camel-version>4.18.0.redhat-00001</camel-version>
+		<camel-community-version>4.18.0</camel-community-version>
 		<camel.sap.plugin.version>4.18.0-SNAPSHOT</camel.sap.plugin.version>
 		<mockito.version>3.12.4</mockito.version>
 		<powermock.version>2.0.2</powermock.version>


### PR DESCRIPTION
EndpointUriFactory API changed between camel 4.14 and 4.15 in https://issues.apache.org/jira/browse/CAMEL-22486 - change multiValuePrefixes from `Set<String>` to `Map<String,String>` and use an emptyMap rather than an emptySet for initialization.

May need to make some changes in sap-quickstarts in this area but it'd be good to get a build of fuse-components to test things out with.