### PR TITLE
Use 4.18.1 versions

### DIFF
--- a/camel-cics/pom.xml
+++ b/camel-cics/pom.xml
@@ -41,7 +41,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j-api-version>2.0.17</slf4j-api-version>
         <cgtclient-version>9.2</cgtclient-version>
-        <camel-version>4.18.0.redhat-00001</camel-version>
+        <camel-version>4.18.1.redhat-00001</camel-version>
         <jdk.version>17</jdk.version>
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>

--- a/camel-sap/pom.xml
+++ b/camel-sap/pom.xml
@@ -32,9 +32,9 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven-surefire-plugin-version>3.5.3</maven-surefire-plugin-version>
 		<maven-bundle-plugin-version>5.1.8</maven-bundle-plugin-version>
-		<camel-version>4.18.0.redhat-00001</camel-version>
-		<camel-community-version>4.18.0</camel-community-version>
-		<camel.sap.plugin.version>4.18.0-SNAPSHOT</camel.sap.plugin.version>
+		<camel-version>4.18.1.redhat-00001</camel-version>
+		<camel-community-version>4.18.1</camel-community-version>
+		<camel.sap.plugin.version>4.18.1-SNAPSHOT</camel.sap.plugin.version>
 		<mockito.version>3.12.4</mockito.version>
 		<powermock.version>2.0.2</powermock.version>
 		<hamcrest.version>2.1</hamcrest.version>


### PR DESCRIPTION
The 4.18.1 productized versions here do not exist yet but this should be enough to enable a build when camel is productized.