### PR TITLE
camel-sap: make TID store location configurable via system property

### DIFF
--- a/camel-sap/camel-sap-component/src/main/java/org/fusesource/camel/component/sap/ServerManager.java
+++ b/camel-sap/camel-sap-component/src/main/java/org/fusesource/camel/component/sap/ServerManager.java
@@ -46,7 +46,7 @@ public enum ServerManager {
 
 	protected static final Map<String, JCoIDocServer> activeServers = new HashMap<String, JCoIDocServer>();
 
-	protected static final File tidStoresLocation = new File(".");
+	protected static final File tidStoresLocation = new File(System.getProperty("org.fusesource.camel.component.sap.tid.store.location", "."));
 
 	protected static final Map<String, JCoCustomRepository> repositories = new HashMap<String, JCoCustomRepository>();
 


### PR DESCRIPTION
The ServerTIDHandler writes transaction ID files to the current working directory (hardcoded as new File(".")). On OCP, the container runs from / as a non-root user, so the write fails with Permission denied.

Make the path configurable via system property
org.fusesource.camel.component.sap.tid.store.location, defaulting to "." for backward compatibility. On OCP, set it to /tmp or /deployments.

Fixes: CSB-9723